### PR TITLE
Load JWT secret from env

### DIFF
--- a/dashboard-backend/.env.example
+++ b/dashboard-backend/.env.example
@@ -1,0 +1,2 @@
+JWT_SECRET=your_jwt_secret_here
+DATABASE_URL=your_database_connection_string

--- a/dashboard-backend/README.md
+++ b/dashboard-backend/README.md
@@ -31,6 +31,11 @@
 $ npm install
 ```
 
+Create a `.env` file in `dashboard-backend` based on `.env.example` and set the required variables:
+
+- `JWT_SECRET` – secret key used to sign JWT tokens
+- `DATABASE_URL` – connection string for your PostgreSQL database
+
 ## Compile and run the project
 
 ```bash

--- a/dashboard-backend/package-lock.json
+++ b/dashboard-backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^11.0.1",
+        "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
         "@nestjs/jwt": "^11.0.0",
         "@nestjs/platform-express": "^11.0.1",
@@ -2506,6 +2507,21 @@
         "class-validator": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/config": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.2.tgz",
+      "integrity": "sha512-McMW6EXtpc8+CwTUwFdg6h7dYcBUpH5iUILCclAsa+MbCEvC9ZKu4dCHRlJqALuhjLw97pbQu62l4+wRwGeZqA==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "16.4.7",
+        "dotenv-expand": "12.0.1",
+        "lodash": "4.17.21"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "rxjs": "^7.1.0"
       }
     },
     "node_modules/@nestjs/core": {
@@ -6029,6 +6045,33 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.1.tgz",
+      "integrity": "sha512-LaKRbou8gt0RNID/9RoI+J2rvXsBRPMV7p+ElHlPhcSARbCPDYcYG2s1TIzAfWv4YSgyY5taidWzzs31lNV3yQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -8737,7 +8780,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.includes": {

--- a/dashboard-backend/package.json
+++ b/dashboard-backend/package.json
@@ -23,6 +23,7 @@
     "@nestjs/common": "^11.0.1",
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.0",
+    "@nestjs/config": "^4.0.2",
     "@nestjs/platform-express": "^11.0.1",
     "@prisma/client": "^6.9.0",
     "bcrypt": "^6.0.0",

--- a/dashboard-backend/src/1-presentation/auth/auth.module.ts
+++ b/dashboard-backend/src/1-presentation/auth/auth.module.ts
@@ -1,19 +1,24 @@
 // src/1-presentation/auth/auth.module.ts
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AuthController } from './auth.controller';
 import { LoginUseCase } from 'src/2-application/use-cases/auth/login.use-case';
 import { DatabaseModule } from 'src/4-infrastructure/database/database.module';
 
 @Module({
   imports: [
+    ConfigModule,
     // On importe le module Database pour avoir accès au IUserRepository
     DatabaseModule,
     // On configure le module JWT
-    JwtModule.register({
+    JwtModule.registerAsync({
       global: true, // Rend le JwtService disponible dans toute l'application
-      secret: 'VOTRE_SECRET_JWT_TRES_COMPLIQUE', // !! À METTRE DANS .env EN PRODUCTION !!
-      signOptions: { expiresIn: '8h' }, // Le token expirera après 8 heures
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET'),
+        signOptions: { expiresIn: '8h' }, // Le token expirera après 8 heures
+      }),
     }),
   ],
   controllers: [AuthController],

--- a/dashboard-backend/src/app.module.ts
+++ b/dashboard-backend/src/app.module.ts
@@ -1,12 +1,14 @@
 // src/app.module.ts
 
 import { Module, MiddlewareConsumer, NestModule } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { AuthModule } from './1-presentation/auth/auth.module';
 import { DatabaseModule } from './4-infrastructure/database/database.module';
 import { LoggerMiddleware } from './logger.middleware'; // <--- 1. IMPORTER L'ESPION
 
 @Module({
   imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
     DatabaseModule,
     AuthModule,
   ],


### PR DESCRIPTION
## Summary
- use ConfigModule and ConfigService for JWT secret
- configure ConfigModule globally in AppModule
- add example environment variables and document them in README

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_685279893620832c983fae4cd8397475